### PR TITLE
Configuração do arquivo git.ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# PYTHON
+
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pyc
+*.pkl
+*.egg-info/
+*.egg
+*.sqlite3
+
+# Ambientes virtuais
+venv/
+.venv/
+env/
+.env
+*.env
+
+
+# NODE / JS
+
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+
+# SISTEMAS / IDEs
+
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+
+# TESTES / TEMPORÁRIOS
+
+*.log
+*.tmp
+.cache/
+coverage/
+coverage.xml
+htmlcov/
+.tox/
+.pytest_cache/
+.mypy_cache/


### PR DESCRIPTION
Este PR atualiza o arquivo `.gitignore` do projeto, adicionando regras adequadas para:

- Arquivos e pastas do Python (ex: `__pycache__`, `.venv/`, etc.)
- Pastas e logs do Node.js (ex: `node_modules/`, `*.log`)
- Pastas de IDEs e arquivos temporários (`.vscode/`, `.DS_Store`, etc.)

✅Objetivo: manter o repositório limpo e organizado, evitando o versionamento de arquivos desnecessários e temporários.